### PR TITLE
DEVOPS-3882 - Adding branch protection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ArcadiaPower/security @ArcadiaPower/sre

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ArcadiaPower/security @ArcadiaPower/sre
+* @ArcadiaPower/sre @ArcadiaPower/internal-security


### PR DESCRIPTION
DEVOPS-3882

Adding CODEOWNERS file in preparation for branch protection.
For now, adding SRE and internal-security (as Clif is on the main security group)

SRE could already direct mainline write, this will add PR protection against mainline after I add the restriction to require at least one approver from codeowners.